### PR TITLE
fix a non-breaking(?) error in the build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "run-script-os",
     "build:linux": "rm -r dist/ && ./node_modules/.bin/tsc && cd src && find -name '*.css' -exec cp --parents {} ../dist/ \\; && cd ..",
-    "build:darwin:linux": "rm -rf dist/ && ./node_modules/.bin/tsc && cd src && find . -name '*.css' -exec ditto {} ../dist/ \\; && cd ..",
+    "build:macos": "rm -rf dist/ && ./node_modules/.bin/tsc && cd src && find . -name '*.css' -exec ditto {} ../dist/ \\; && cd ..",
     "react": "react-scripts start",
     "electron": "electron .",
     "kill": "fuser -k 3000/tcp",


### PR DESCRIPTION
The build script currently labels the macos version of the script with `:darwin:linux` like in the `run-script-os` example, but the label for macos is actually just `:darwin`. `:darwin:linux` is actually a compound label that labels a script for both macos and linux.

I think it was non-breaking, because there was another `build:linux` script before the `build:darwin:linux` script, and the script router just ran the first one and stopped.

I also swapped the label from `:darwin` to its alias `:macos` for clarity.